### PR TITLE
use base activemq script instead of x64, to allow env vars to be passed to amq

### DIFF
--- a/assets/setup/install
+++ b/assets/setup/install
@@ -75,7 +75,7 @@ cat > /etc/supervisor/conf.d/activemq.conf <<EOF
 [program:activemq]
 priority=20
 directory=/tmp
-command=/opt/activemq/bin/linux-x86-64/activemq console
+command=/opt/activemq/bin/activemq console
 user=root
 autostart=true
 autorestart=true


### PR DESCRIPTION
This allows for passing env vars through docker:

`docker run --rm -p5555:5555 -p8161:8161 --name amq -e 'ACTIVEMQ_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5555"' webcenter/activemq`

I don't know if we are supposed to use the x64 script instead of the default.

fixes #16 
